### PR TITLE
Add repository query methods

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/repository/EventRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/EventRepository.java
@@ -1,7 +1,37 @@
 package com.ubb.eventappbackend.repository;
 
 import com.ubb.eventappbackend.model.Event;
+import com.ubb.eventappbackend.model.EventSourceType;
+import com.ubb.eventappbackend.model.Visibility;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface EventRepository extends JpaRepository<Event, String> {
+
+    /**
+     * Retrieves events that start within the specified date range.
+     *
+     * @param start start date-time of the range (inclusive)
+     * @param end   end date-time of the range (inclusive)
+     * @return list of events in the given range
+     */
+    List<Event> findByFechaInicioBetween(LocalDateTime start, LocalDateTime end);
+
+    /**
+     * Retrieves events with the given visibility.
+     *
+     * @param visibilidad visibility to match
+     * @return list of events matching the visibility
+     */
+    List<Event> findByVisibilidad(Visibility visibilidad);
+
+    /**
+     * Retrieves events whose origin matches the provided type.
+     *
+     * @param origenTipo origin type of the event
+     * @return list of events originating from the given source type
+     */
+    List<Event> findByOrigenTipo(EventSourceType origenTipo);
 }

--- a/src/main/java/com/ubb/eventappbackend/repository/FriendshipRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/FriendshipRepository.java
@@ -2,7 +2,23 @@ package com.ubb.eventappbackend.repository;
 
 import com.ubb.eventappbackend.model.Friendship;
 import com.ubb.eventappbackend.model.FriendshipId;
+import com.ubb.eventappbackend.model.FriendshipState;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, FriendshipId> {
+
+    /**
+     * Returns friendships of a user matching the given state. The user can be
+     * either in the {@code user1} or {@code user2} position of the friendship.
+     *
+     * @param userId identifier of the user
+     * @param estado desired friendship state
+     * @return list of friendships for the user in the specified state
+     */
+    @Query("select f from Friendship f where (f.user1.id = :userId or f.user2.id = :userId) and f.estado = :estado")
+    List<Friendship> findByUserIdAndEstado(@Param("userId") String userId, @Param("estado") FriendshipState estado);
 }

--- a/src/main/java/com/ubb/eventappbackend/repository/GroupRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/GroupRepository.java
@@ -3,5 +3,15 @@ package com.ubb.eventappbackend.repository;
 import com.ubb.eventappbackend.model.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GroupRepository extends JpaRepository<Group, String> {
+
+    /**
+     * Finds groups whose {@code nombre} contains the provided text, ignoring case.
+     *
+     * @param nombre part of the group name to search for
+     * @return list of groups with matching names
+     */
+    List<Group> findByNombreContainingIgnoreCase(String nombre);
 }

--- a/src/main/java/com/ubb/eventappbackend/repository/RegistrationRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/RegistrationRepository.java
@@ -2,7 +2,19 @@ package com.ubb.eventappbackend.repository;
 
 import com.ubb.eventappbackend.model.Registration;
 import com.ubb.eventappbackend.model.RegistrationId;
+import com.ubb.eventappbackend.model.RegistrationState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RegistrationRepository extends JpaRepository<Registration, RegistrationId> {
+
+    /**
+     * Finds event registrations for a user with the specified state.
+     *
+     * @param userId identifier of the user
+     * @param estado state of the registration
+     * @return list of registrations that match
+     */
+    List<Registration> findByUser_IdAndEstado(String userId, RegistrationState estado);
 }


### PR DESCRIPTION
## Summary
- extend `GroupRepository` with a method to search by name text
- add filtering queries for `EventRepository`
- support searching friendships by user and state
- allow retrieving registrations by user and state

## Testing
- `mvn -q -DskipTests=false test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686c9c6075808320848090f0c005095f