### PR TITLE
Add group search queries

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/model/Group.java
+++ b/src/main/java/com/ubb/eventappbackend/model/Group.java
@@ -2,6 +2,7 @@ package com.ubb.eventappbackend.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.util.Set;
 
 @Entity
 @Table(name = "grupo")
@@ -27,4 +28,10 @@ public class Group {
     @ManyToOne
     @JoinColumn(name = "id_campus")
     private Campus campus;
+
+    @ManyToMany
+    @JoinTable(name = "grupo_tag",
+            joinColumns = @JoinColumn(name = "id_grupo"),
+            inverseJoinColumns = @JoinColumn(name = "id_tag"))
+    private Set<Tag> tags;
 }

--- a/src/main/java/com/ubb/eventappbackend/model/Tag.java
+++ b/src/main/java/com/ubb/eventappbackend/model/Tag.java
@@ -2,6 +2,7 @@ package com.ubb.eventappbackend.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -17,4 +18,7 @@ public class Tag {
 
     @Column(length = 60, unique = true)
     private String nombre;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Group> grupos;
 }

--- a/src/main/java/com/ubb/eventappbackend/repository/GroupRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/GroupRepository.java
@@ -1,9 +1,14 @@
 package com.ubb.eventappbackend.repository;
 
 import com.ubb.eventappbackend.model.Group;
+import com.ubb.eventappbackend.model.GroupMember;
+import com.ubb.eventappbackend.model.GroupRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Collection;
 
 public interface GroupRepository extends JpaRepository<Group, String> {
 
@@ -14,4 +19,21 @@ public interface GroupRepository extends JpaRepository<Group, String> {
      * @return list of groups with matching names
      */
     List<Group> findByNombreContainingIgnoreCase(String nombre);
+
+    /**
+     * Finds groups where the given user is registered as representative.
+     *
+     * @param userId id of the representative user
+     * @return list of groups represented by the user
+     */
+    @Query("select gm.group from GroupMember gm where gm.user.id = :userId and gm.rolGrupo = com.ubb.eventappbackend.model.GroupRole.REPRESENTANTE")
+    List<Group> findByRepresentativeUser(@Param("userId") String userId);
+
+    /**
+     * Finds groups that are associated with any of the provided tag ids.
+     *
+     * @param tagIds list of tag ids to search for
+     * @return list of groups having at least one of the tags
+     */
+    List<Group> findDistinctByTagsIdIn(Collection<Integer> tagIds);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/GroupService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/GroupService.java
@@ -2,10 +2,28 @@ package com.ubb.eventappbackend.service;
 
 import com.ubb.eventappbackend.model.Group;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupService {
     Group createGroup(Group group);
     Group updateGroup(Group group);
     Optional<Group> findById(String id);
+
+    /**
+     * Retrieves groups represented by the specified user.
+     *
+     * @param userId the representative user id
+     * @return list of groups where the user is representative
+     */
+    List<Group> findByRepresentativeUser(String userId);
+
+    /**
+     * Retrieves groups that contain any of the provided tags.
+     *
+     * @param tagIds collection of tag ids
+     * @return list of groups having at least one of the tags
+     */
+    List<Group> findByTags(Collection<Integer> tagIds);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/impl/GroupServiceImpl.java
+++ b/src/main/java/com/ubb/eventappbackend/service/impl/GroupServiceImpl.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -30,5 +32,17 @@ public class GroupServiceImpl implements GroupService {
     @Transactional(readOnly = true)
     public Optional<Group> findById(String id) {
         return groupRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Group> findByRepresentativeUser(String userId) {
+        return groupRepository.findByRepresentativeUser(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Group> findByTags(Collection<Integer> tagIds) {
+        return groupRepository.findDistinctByTagsIdIn(tagIds);
     }
 }


### PR DESCRIPTION
## Summary
- connect `Group` and `Tag` with a many-to-many relation
- expose new repository queries to find groups by representative user and by tags
- add service methods delegating to repository for the new search logic

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9f2aff488320ad35fb10d49d5704