### PR TITLE
Add query helpers for Event calendar views

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/repository/EventRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/EventRepository.java
@@ -34,4 +34,28 @@ public interface EventRepository extends JpaRepository<Event, String> {
      * @return list of events originating from the given source type
      */
     List<Event> findByOrigenTipo(EventSourceType origenTipo);
+
+    /**
+     * Finds events created by the specified user.
+     *
+     * @param userId identifier of the creator
+     * @return list of events created by the user
+     */
+    List<Event> findByCreador_Id(String userId);
+
+    /**
+     * Retrieves all events belonging to the given group.
+     *
+     * @param groupId identifier of the group
+     * @return list of events for that group
+     */
+    List<Event> findByGrupo_Id(String groupId);
+
+    /**
+     * Fetches events that start after the provided date.
+     *
+     * @param date starting date-time (exclusive)
+     * @return list of upcoming events
+     */
+    List<Event> findByFechaInicioAfter(LocalDateTime date);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/EventService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/EventService.java
@@ -9,4 +9,8 @@ public interface EventService {
     Event updateEvent(Event event);
     Event approveEvent(String eventId);
     Optional<Event> findById(String id);
+
+    java.util.List<Event> findByCreator(String userId);
+    java.util.List<Event> findByGroup(String groupId);
+    java.util.List<Event> findUpcomingEvents(java.time.LocalDateTime after);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/ubb/eventappbackend/service/impl/EventServiceImpl.java
@@ -39,4 +39,22 @@ public class EventServiceImpl implements EventService {
     public Optional<Event> findById(String id) {
         return eventRepository.findById(id);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public java.util.List<Event> findByCreator(String userId) {
+        return eventRepository.findByCreador_Id(userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public java.util.List<Event> findByGroup(String groupId) {
+        return eventRepository.findByGrupo_Id(groupId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public java.util.List<Event> findUpcomingEvents(java.time.LocalDateTime after) {
+        return eventRepository.findByFechaInicioAfter(after);
+    }
 }


### PR DESCRIPTION
## Summary
- add user, group and upcoming event queries in `EventRepository`
- expose helper methods in `EventService` and its implementation

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin couldn't resolve)*

------
https://chatgpt.com/codex/tasks/task_e_686c9f350b608320a779184fde5722ce