### PR TITLE
Implement user profile summary service

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/model/ProfileSummary.java
+++ b/src/main/java/com/ubb/eventappbackend/model/ProfileSummary.java
@@ -1,0 +1,24 @@
+package com.ubb.eventappbackend.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Aggregated view of a user's profile information.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileSummary {
+    private long friendCount;
+    private long attendedEvents;
+    private long createdEvents;
+    private List<Trophy> trophies;
+}

--- a/src/main/java/com/ubb/eventappbackend/repository/EventRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/EventRepository.java
@@ -34,4 +34,12 @@ public interface EventRepository extends JpaRepository<Event, String> {
      * @return list of events originating from the given source type
      */
     List<Event> findByOrigenTipo(EventSourceType origenTipo);
+
+    /**
+     * Counts events created by the specified user.
+     *
+     * @param creadorId identifier of the user
+     * @return number of events where the given user is creator
+     */
+    long countByCreador_Id(String creadorId);
 }

--- a/src/main/java/com/ubb/eventappbackend/repository/UserTrophyRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/UserTrophyRepository.java
@@ -2,7 +2,15 @@ package com.ubb.eventappbackend.repository;
 
 import com.ubb.eventappbackend.model.UserTrophy;
 import com.ubb.eventappbackend.model.UserTrophyId;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserTrophyRepository extends JpaRepository<UserTrophy, UserTrophyId> {
+    /**
+     * Retrieves trophies obtained by the given user.
+     *
+     * @param userId identifier of the user
+     * @return list of user trophies
+     */
+    List<UserTrophy> findByUser_Id(String userId);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/UserService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/UserService.java
@@ -1,6 +1,7 @@
 package com.ubb.eventappbackend.service;
 
 import com.ubb.eventappbackend.model.User;
+import com.ubb.eventappbackend.model.ProfileSummary;
 
 import java.util.Optional;
 
@@ -8,4 +9,12 @@ public interface UserService {
     User registerUser(User user);
     User updateProfile(User user);
     Optional<User> findById(String id);
+
+    /**
+     * Returns aggregated profile data for the given user.
+     *
+     * @param userId identifier of the user
+     * @return summary object with counts and trophies
+     */
+    ProfileSummary getProfileSummary(String userId);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/ubb/eventappbackend/service/impl/UserServiceImpl.java
@@ -1,8 +1,17 @@
 package com.ubb.eventappbackend.service.impl;
 
+import com.ubb.eventappbackend.model.ProfileSummary;
+import com.ubb.eventappbackend.model.Trophy;
 import com.ubb.eventappbackend.model.User;
+import com.ubb.eventappbackend.model.FriendshipState;
+import com.ubb.eventappbackend.model.RegistrationState;
 import com.ubb.eventappbackend.repository.UserRepository;
+import com.ubb.eventappbackend.repository.FriendshipRepository;
+import com.ubb.eventappbackend.repository.RegistrationRepository;
+import com.ubb.eventappbackend.repository.EventRepository;
+import com.ubb.eventappbackend.repository.UserTrophyRepository;
 import com.ubb.eventappbackend.service.UserService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +24,10 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final RegistrationRepository registrationRepository;
+    private final EventRepository eventRepository;
+    private final UserTrophyRepository userTrophyRepository;
 
     @Override
     public User registerUser(User user) {
@@ -30,5 +43,31 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public Optional<User> findById(String id) {
         return userRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProfileSummary getProfileSummary(String userId) {
+        long friendCount = friendshipRepository
+                .findByUserIdAndEstado(userId, FriendshipState.ACEPTADA)
+                .size();
+
+        long attendedEvents = registrationRepository
+                .findByUser_IdAndEstado(userId, RegistrationState.ASISTIO)
+                .size();
+
+        long createdEvents = eventRepository.countByCreador_Id(userId);
+
+        List<Trophy> trophies = userTrophyRepository.findByUser_Id(userId)
+                .stream()
+                .map(ut -> ut.getTrophy())
+                .toList();
+
+        return ProfileSummary.builder()
+                .friendCount(friendCount)
+                .attendedEvents(attendedEvents)
+                .createdEvents(createdEvents)
+                .trophies(trophies)
+                .build();
     }
 }


### PR DESCRIPTION
## Summary
- define `ProfileSummary` model class
- expose `countByCreador_Id` in `EventRepository`
- expose `findByUser_Id` in `UserTrophyRepository`
- add `getProfileSummary` to `UserService`
- implement profile summary logic in `UserServiceImpl`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9f3d80ac8320a386711fe2c655c6