### PR TITLE
Implement profile summary retrieval

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/model/ProfileSummary.java
+++ b/src/main/java/com/ubb/eventappbackend/model/ProfileSummary.java
@@ -1,0 +1,24 @@
+package com.ubb.eventappbackend.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * Simple DTO aggregating basic profile information for a user.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileSummary {
+    private long friendsCount;
+    private long eventsAttended;
+    private long eventsCreated;
+    private List<Trophy> trophies;
+}

--- a/src/main/java/com/ubb/eventappbackend/repository/UserTrophyRepository.java
+++ b/src/main/java/com/ubb/eventappbackend/repository/UserTrophyRepository.java
@@ -5,4 +5,11 @@ import com.ubb.eventappbackend.model.UserTrophyId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserTrophyRepository extends JpaRepository<UserTrophy, UserTrophyId> {
+    /**
+     * Retrieves trophies obtained by the given user.
+     *
+     * @param userId id of the user
+     * @return list of user trophies
+     */
+    java.util.List<UserTrophy> findByUser_Id(String userId);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/UserService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/UserService.java
@@ -1,6 +1,7 @@
 package com.ubb.eventappbackend.service;
 
 import com.ubb.eventappbackend.model.User;
+import com.ubb.eventappbackend.model.ProfileSummary;
 
 import java.util.Optional;
 
@@ -8,4 +9,12 @@ public interface UserService {
     User registerUser(User user);
     User updateProfile(User user);
     Optional<User> findById(String id);
+
+    /**
+     * Aggregates some statistics for the user's profile page.
+     *
+     * @param userId id of the user to summarize
+     * @return summary object with counts and trophies
+     */
+    ProfileSummary getProfileSummary(String userId);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/ubb/eventappbackend/service/impl/UserServiceImpl.java
@@ -1,7 +1,16 @@
 package com.ubb.eventappbackend.service.impl;
 
 import com.ubb.eventappbackend.model.User;
+import com.ubb.eventappbackend.model.ProfileSummary;
+import com.ubb.eventappbackend.model.FriendshipState;
+import com.ubb.eventappbackend.model.RegistrationState;
+import com.ubb.eventappbackend.model.Trophy;
+import com.ubb.eventappbackend.model.UserTrophy;
 import com.ubb.eventappbackend.repository.UserRepository;
+import com.ubb.eventappbackend.repository.FriendshipRepository;
+import com.ubb.eventappbackend.repository.RegistrationRepository;
+import com.ubb.eventappbackend.repository.EventRepository;
+import com.ubb.eventappbackend.repository.UserTrophyRepository;
 import com.ubb.eventappbackend.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +24,10 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final RegistrationRepository registrationRepository;
+    private final EventRepository eventRepository;
+    private final UserTrophyRepository userTrophyRepository;
 
     @Override
     public User registerUser(User user) {
@@ -30,5 +43,34 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public Optional<User> findById(String id) {
         return userRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProfileSummary getProfileSummary(String userId) {
+        long friendCount = friendshipRepository
+                .findByUserIdAndEstado(userId, FriendshipState.ACEPTADA)
+                .size();
+
+        long eventsAttended = registrationRepository
+                .findByUser_IdAndEstado(userId, RegistrationState.ASISTIO)
+                .size();
+
+        long eventsCreated = eventRepository
+                .findByCreador_Id(userId)
+                .size();
+
+        java.util.List<Trophy> trophies = userTrophyRepository
+                .findByUser_Id(userId)
+                .stream()
+                .map(UserTrophy::getTrophy)
+                .toList();
+
+        return ProfileSummary.builder()
+                .friendsCount(friendCount)
+                .eventsAttended(eventsAttended)
+                .eventsCreated(eventsCreated)
+                .trophies(trophies)
+                .build();
     }
 }


### PR DESCRIPTION
## Summary
- create `ProfileSummary` model for profile statistics
- extend `UserTrophyRepository` with query method
- add `getProfileSummary` to `UserService`
- implement logic in `UserServiceImpl` using existing repositories

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca5c92f808320b5cbe6b4fcc5d2ff