### PR TITLE
Add events calendar retrieval

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/model/EventsToAttend.java
+++ b/src/main/java/com/ubb/eventappbackend/model/EventsToAttend.java
@@ -1,0 +1,21 @@
+package com.ubb.eventappbackend.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * DTO containing identifiers of events the user plans to attend.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EventsToAttend {
+    private List<String> eventIds;
+}

--- a/src/main/java/com/ubb/eventappbackend/model/ProfileEvents.java
+++ b/src/main/java/com/ubb/eventappbackend/model/ProfileEvents.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
 
 /**
  * DTO aggregating event statistics for a user.
@@ -19,5 +18,8 @@ import java.util.List;
 public class ProfileEvents {
     private long eventsAttended;
     private long eventsCreated;
-    private List<CalendarEntry> calendar;
+    /**
+     * Number of future events the user is registered to attend.
+     */
+    private long eventsToAttend;
 }

--- a/src/main/java/com/ubb/eventappbackend/model/ProfileSummary.java
+++ b/src/main/java/com/ubb/eventappbackend/model/ProfileSummary.java
@@ -23,4 +23,8 @@ public class ProfileSummary {
     private String username;
     private long friendsCount;
     private List<Trophy> trophies;
+    /**
+     * Aggregated statistics about the user's events.
+     */
+    private ProfileEvents events;
 }

--- a/src/main/java/com/ubb/eventappbackend/service/EventService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/EventService.java
@@ -13,4 +13,12 @@ public interface EventService {
     java.util.List<Event> findByCreator(String userId);
     java.util.List<Event> findByGroup(String groupId);
     java.util.List<Event> findUpcomingEvents(java.time.LocalDateTime after);
+
+    /**
+     * Retrieves the events with the provided identifiers.
+     *
+     * @param ids list of event ids
+     * @return list of events found
+     */
+    java.util.List<Event> findByIds(java.util.List<String> ids);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/UserService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/UserService.java
@@ -3,6 +3,8 @@ package com.ubb.eventappbackend.service;
 import com.ubb.eventappbackend.model.User;
 import com.ubb.eventappbackend.model.ProfileSummary;
 import com.ubb.eventappbackend.model.ProfileEvents;
+import com.ubb.eventappbackend.model.EventsToAttend;
+import com.ubb.eventappbackend.model.CalendarEntry;
 
 import java.util.Optional;
 
@@ -26,4 +28,21 @@ public interface UserService {
      * @return event summary information
      */
     ProfileEvents getProfileEvents(String userId);
+
+    /**
+     * Builds a calendar of all events the user has created, attended or plans
+     * to attend.
+     *
+     * @param userId id of the user
+     * @return list of calendar entries grouped by date
+     */
+    java.util.List<CalendarEntry> getEventCalendar(String userId);
+
+    /**
+     * Lists the identifiers of future events the user plans to attend.
+     *
+     * @param userId id of the user
+     * @return wrapper object with event ids
+     */
+    EventsToAttend getEventsToAttend(String userId);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/ubb/eventappbackend/service/impl/EventServiceImpl.java
@@ -57,4 +57,11 @@ public class EventServiceImpl implements EventService {
     public java.util.List<Event> findUpcomingEvents(java.time.LocalDateTime after) {
         return eventRepository.findByFechaInicioAfter(after);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public java.util.List<Event> findByIds(java.util.List<String> ids) {
+        return ids == null || ids.isEmpty() ? java.util.Collections.emptyList() :
+                eventRepository.findAllById(ids);
+    }
 }

--- a/src/test/java/com/ubb/eventappbackend/service/impl/EventServiceImplTest.java
+++ b/src/test/java/com/ubb/eventappbackend/service/impl/EventServiceImplTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Optional;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -35,5 +36,14 @@ public class EventServiceImplTest {
         ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
         verify(eventRepository).save(captor.capture());
         assertEquals(ValidationState.APROBADO, captor.getValue().getEstadoValidacion());
+    }
+
+    @Test
+    void findByIds_delegatesToRepository() {
+        when(eventRepository.findAllById(List.of("e1", "e2"))).thenReturn(List.of(new Event(), new Event()));
+
+        service.findByIds(List.of("e1", "e2"));
+
+        verify(eventRepository).findAllById(List.of("e1", "e2"));
     }
 }

--- a/src/test/java/com/ubb/eventappbackend/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/ubb/eventappbackend/service/impl/UserServiceImplTest.java
@@ -5,6 +5,7 @@ import com.ubb.eventappbackend.repository.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,10 +41,75 @@ public class UserServiceImplTest {
         UserTrophy ut = UserTrophy.builder().trophy(trophy).build();
         when(userTrophyRepository.findByUser_Id("u1")).thenReturn(List.of(ut));
 
+        LocalDateTime now = LocalDateTime.now();
+        Event createdEvent = Event.builder().id("e1").fechaInicio(now).build();
+        when(eventRepository.findByCreador_Id("u1")).thenReturn(List.of(createdEvent));
+        Registration attended = Registration.builder()
+                .event(Event.builder().id("e2").fechaInicio(now).build())
+                .build();
+        when(registrationRepository.findByUser_IdAndEstado("u1", RegistrationState.ASISTIO))
+                .thenReturn(List.of(attended));
+        Registration toAttend = Registration.builder()
+                .event(Event.builder().id("e3").fechaInicio(now).build())
+                .build();
+        when(registrationRepository.findByUser_IdAndEstado("u1", RegistrationState.INSCRITO))
+                .thenReturn(List.of(toAttend));
+
         ProfileSummary summary = service.getProfileSummary("u1");
 
         assertEquals("john", summary.getUsername());
         assertEquals(2, summary.getFriendsCount());
         assertEquals(List.of(trophy), summary.getTrophies());
+        assertNotNull(summary.getEvents());
+        assertEquals(1, summary.getEvents().getEventsCreated());
+        assertEquals(1, summary.getEvents().getEventsAttended());
+        assertEquals(1, summary.getEvents().getEventsToAttend());
+    }
+
+    @Test
+    void getProfileEvents_buildsEventSummaryFromRepositories() {
+        LocalDateTime now = LocalDateTime.now();
+        when(eventRepository.findByCreador_Id("u1"))
+                .thenReturn(List.of(Event.builder().id("e1").fechaInicio(now).build()));
+        Registration attended = Registration.builder()
+                .event(Event.builder().id("e2").fechaInicio(now).build())
+                .build();
+        when(registrationRepository.findByUser_IdAndEstado("u1", RegistrationState.ASISTIO))
+                .thenReturn(List.of(attended));
+        Registration toAttend = Registration.builder()
+                .event(Event.builder().id("e3").fechaInicio(now).build())
+                .build();
+        when(registrationRepository.findByUser_IdAndEstado("u1", RegistrationState.INSCRITO))
+                .thenReturn(List.of(toAttend));
+
+        ProfileEvents result = service.getProfileEvents("u1");
+
+        assertEquals(1, result.getEventsCreated());
+        assertEquals(1, result.getEventsAttended());
+        assertEquals(1, result.getEventsToAttend());
+
+        List<CalendarEntry> calendar = service.getEventCalendar("u1");
+
+        assertEquals(1, calendar.size());
+        assertTrue(calendar.get(0).getEventIds().contains("e1"));
+        assertTrue(calendar.get(0).getEventIds().contains("e2"));
+        assertTrue(calendar.get(0).getEventIds().contains("e3"));
+    }
+
+    @Test
+    void getEventsToAttend_returnsIdsOfUpcomingEvents() {
+        Registration toAttend1 = Registration.builder()
+                .event(Event.builder().id("e1").build())
+                .build();
+        Registration toAttend2 = Registration.builder()
+                .event(Event.builder().id("e2").build())
+                .build();
+        when(registrationRepository.findByUser_IdAndEstado("u1", RegistrationState.INSCRITO))
+                .thenReturn(List.of(toAttend1, toAttend2));
+
+        EventsToAttend result = service.getEventsToAttend("u1");
+        List<String> ids = result.getEventIds();
+
+        assertEquals(List.of("e1", "e2"), ids);
     }
 }


### PR DESCRIPTION
## Summary
- remove calendar from `ProfileEvents`
- add `getEventCalendar` service method
- implement method in service implementation and update profile events
- revised unit tests
- document profile summary method uses `getProfileEvents`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3ac85c6883208c5781fc80335ce8