### PR TITLE
Add basic REST controllers

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/controller/EventController.java
+++ b/src/main/java/com/ubb/eventappbackend/controller/EventController.java
@@ -1,0 +1,63 @@
+package com.ubb.eventappbackend.controller;
+
+import com.ubb.eventappbackend.model.Event;
+import com.ubb.eventappbackend.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService service;
+
+    @PostMapping
+    public ResponseEntity<Event> create(@RequestBody Event event) {
+        return ResponseEntity.ok(service.createEvent(event));
+    }
+
+    @PutMapping
+    public ResponseEntity<Event> update(@RequestBody Event event) {
+        return ResponseEntity.ok(service.updateEvent(event));
+    }
+
+    @PostMapping("/{id}/approve")
+    public ResponseEntity<Event> approve(@PathVariable String id) {
+        return ResponseEntity.ok(service.approveEvent(id));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Event> findById(@PathVariable String id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/creator/{userId}")
+    public ResponseEntity<List<Event>> findByCreator(@PathVariable String userId) {
+        return ResponseEntity.ok(service.findByCreator(userId));
+    }
+
+    @GetMapping("/group/{groupId}")
+    public ResponseEntity<List<Event>> findByGroup(@PathVariable String groupId) {
+        return ResponseEntity.ok(service.findByGroup(groupId));
+    }
+
+    @GetMapping("/upcoming")
+    public ResponseEntity<List<Event>> findUpcoming(@RequestParam(required = false)
+                                                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                                    LocalDateTime after) {
+        return ResponseEntity.ok(service.findUpcomingEvents(after == null ? LocalDateTime.now() : after));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Event>> findByIds(@RequestParam("ids") List<String> ids) {
+        return ResponseEntity.ok(service.findByIds(ids));
+    }
+}

--- a/src/main/java/com/ubb/eventappbackend/controller/FriendshipController.java
+++ b/src/main/java/com/ubb/eventappbackend/controller/FriendshipController.java
@@ -1,0 +1,34 @@
+package com.ubb.eventappbackend.controller;
+
+import com.ubb.eventappbackend.model.Friendship;
+import com.ubb.eventappbackend.model.FriendshipId;
+import com.ubb.eventappbackend.service.FriendshipService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/friendships")
+@RequiredArgsConstructor
+public class FriendshipController {
+
+    private final FriendshipService service;
+
+    @PostMapping
+    public ResponseEntity<Friendship> request(@RequestBody Friendship friendship) {
+        return ResponseEntity.ok(service.requestFriendship(friendship));
+    }
+
+    @PostMapping("/accept")
+    public ResponseEntity<Friendship> accept(@RequestBody FriendshipId id) {
+        return ResponseEntity.ok(service.acceptFriendship(id));
+    }
+
+    @GetMapping("/{user1}/{user2}")
+    public ResponseEntity<Friendship> findById(@PathVariable String user1, @PathVariable String user2) {
+        FriendshipId id = new FriendshipId(user1, user2);
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/ubb/eventappbackend/controller/GroupController.java
+++ b/src/main/java/com/ubb/eventappbackend/controller/GroupController.java
@@ -1,0 +1,50 @@
+package com.ubb.eventappbackend.controller;
+
+import com.ubb.eventappbackend.model.Group;
+import com.ubb.eventappbackend.service.GroupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collection;
+import java.util.List;
+
+@RestController
+@RequestMapping("/groups")
+@RequiredArgsConstructor
+public class GroupController {
+
+    private final GroupService service;
+
+    @PostMapping
+    public ResponseEntity<Group> create(@RequestBody Group group) {
+        return ResponseEntity.ok(service.createGroup(group));
+    }
+
+    @PutMapping
+    public ResponseEntity<Group> update(@RequestBody Group group) {
+        return ResponseEntity.ok(service.updateGroup(group));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Group> findById(@PathVariable String id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/representative/{userId}")
+    public ResponseEntity<List<Group>> findByRepresentative(@PathVariable String userId) {
+        return ResponseEntity.ok(service.findByRepresentativeUser(userId));
+    }
+
+    @GetMapping("/tags")
+    public ResponseEntity<List<Group>> findByTags(@RequestParam("ids") Collection<Integer> ids) {
+        return ResponseEntity.ok(service.findByTags(ids));
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<Group>> searchByName(@RequestParam("name") String name) {
+        return ResponseEntity.ok(service.findByName(name));
+    }
+}

--- a/src/main/java/com/ubb/eventappbackend/controller/RegistrationController.java
+++ b/src/main/java/com/ubb/eventappbackend/controller/RegistrationController.java
@@ -1,0 +1,34 @@
+package com.ubb.eventappbackend.controller;
+
+import com.ubb.eventappbackend.model.Registration;
+import com.ubb.eventappbackend.model.RegistrationId;
+import com.ubb.eventappbackend.service.RegistrationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/registrations")
+@RequiredArgsConstructor
+public class RegistrationController {
+
+    private final RegistrationService service;
+
+    @PostMapping
+    public ResponseEntity<Registration> register(@RequestBody Registration registration) {
+        return ResponseEntity.ok(service.register(registration));
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<Registration> cancel(@RequestBody RegistrationId id) {
+        return ResponseEntity.ok(service.cancelRegistration(id));
+    }
+
+    @GetMapping("/{eventId}/{userId}")
+    public ResponseEntity<Registration> findById(@PathVariable String eventId, @PathVariable String userId) {
+        RegistrationId id = new RegistrationId(eventId, userId);
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/ubb/eventappbackend/controller/SupportTicketController.java
+++ b/src/main/java/com/ubb/eventappbackend/controller/SupportTicketController.java
@@ -1,0 +1,32 @@
+package com.ubb.eventappbackend.controller;
+
+import com.ubb.eventappbackend.model.SupportTicket;
+import com.ubb.eventappbackend.service.SupportTicketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/tickets")
+@RequiredArgsConstructor
+public class SupportTicketController {
+
+    private final SupportTicketService service;
+
+    @PostMapping
+    public ResponseEntity<SupportTicket> open(@RequestBody SupportTicket ticket) {
+        return ResponseEntity.ok(service.openTicket(ticket));
+    }
+
+    @PostMapping("/{id}/close")
+    public ResponseEntity<SupportTicket> close(@PathVariable String id) {
+        return ResponseEntity.ok(service.closeTicket(id));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SupportTicket> findById(@PathVariable String id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/ubb/eventappbackend/controller/UserController.java
+++ b/src/main/java/com/ubb/eventappbackend/controller/UserController.java
@@ -1,0 +1,49 @@
+package com.ubb.eventappbackend.controller;
+
+import com.ubb.eventappbackend.model.*;
+import com.ubb.eventappbackend.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService service;
+
+    @PutMapping
+    public ResponseEntity<User> updateProfile(@RequestBody User user) {
+        return ResponseEntity.ok(service.updateProfile(user));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> findById(@PathVariable String id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/summary")
+    public ResponseEntity<ProfileSummary> getSummary(@PathVariable String id) {
+        return ResponseEntity.ok(service.getProfileSummary(id));
+    }
+
+    @GetMapping("/{id}/events")
+    public ResponseEntity<ProfileEvents> getProfileEvents(@PathVariable String id) {
+        return ResponseEntity.ok(service.getProfileEvents(id));
+    }
+
+    @GetMapping("/{id}/calendar")
+    public ResponseEntity<List<CalendarEntry>> getCalendar(@PathVariable String id) {
+        return ResponseEntity.ok(service.getEventCalendar(id));
+    }
+
+    @GetMapping("/{id}/to-attend")
+    public ResponseEntity<EventsToAttend> eventsToAttend(@PathVariable String id) {
+        return ResponseEntity.ok(service.getEventsToAttend(id));
+    }
+}

--- a/src/main/java/com/ubb/eventappbackend/service/GroupService.java
+++ b/src/main/java/com/ubb/eventappbackend/service/GroupService.java
@@ -26,4 +26,12 @@ public interface GroupService {
      * @return list of groups having at least one of the tags
      */
     List<Group> findByTags(Collection<Integer> tagIds);
+
+    /**
+     * Searches for groups whose name contains the provided text.
+     *
+     * @param name part of the name to look for
+     * @return list of groups matching the name
+     */
+    List<Group> findByName(String name);
 }

--- a/src/main/java/com/ubb/eventappbackend/service/impl/GroupServiceImpl.java
+++ b/src/main/java/com/ubb/eventappbackend/service/impl/GroupServiceImpl.java
@@ -45,4 +45,10 @@ public class GroupServiceImpl implements GroupService {
     public List<Group> findByTags(Collection<Integer> tagIds) {
         return groupRepository.findDistinctByTagsIdIn(tagIds);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Group> findByName(String name) {
+        return groupRepository.findByNombreContainingIgnoreCase(name);
+    }
 }


### PR DESCRIPTION
## Summary
- expose `GroupService#findByName`
- implement REST controllers for events, groups, users, friendships, registrations and support tickets

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686d4774a1908320a0b3a2106e0891d1