### PR TITLE
Use env vars for MySQL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # ubb-eventapp-backend
 Java backend for Event App
+
+## Database Configuration
+
+The application reads the MySQL connection details from environment variables. Create these variables before running the application:
+
+- `DB_URL` – JDBC connection string, e.g. `jdbc:mysql://localhost:3306/eventdb`
+- `DB_USERNAME` – database user
+- `DB_PASSWORD` – database password
+
+Defaults are provided for local development if the variables are not set.

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.28</version>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=${DB_URL:jdbc:mysql://localhost:3306/eventdb}
+spring.datasource.username=${DB_USERNAME:root}
+spring.datasource.password=${DB_PASSWORD:password}
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect


### PR DESCRIPTION
## Summary
- secure MySQL credentials with environment variables
- document DB environment variables
- add MySQL connector dependency

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4baf6a608320ac264c784c7032eb