### PR TITLE
Fix UserDetails usage during authentication

### DIFF
--- a/src/main/java/com/ubb/eventappbackend/config/SecurityBeansConfig.java
+++ b/src/main/java/com/ubb/eventappbackend/config/SecurityBeansConfig.java
@@ -27,8 +27,18 @@ public class SecurityBeansConfig {
 
     @Bean
     public UserDetailsService userDetailsService() {
-        return username -> userRepository.findByCorreoUbb(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return username -> {
+            com.ubb.eventappbackend.model.User user = userRepository.findByCorreoUbb(username)
+                    .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+            return org.springframework.security.core.userdetails.User.builder()
+                    .username(user.getCorreoUbb())
+                    .password(user.getPassword() == null ? "" : user.getPassword())
+                    .authorities(user.getRoles() == null ? java.util.List.of() :
+                            user.getRoles().stream()
+                                    .map(r -> new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_" + r.getNombre().name()))
+                                    .toList())
+                    .build();
+        };
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- convert `User` entities to `UserDetails` when generating/validating JWTs
- update SecurityBeansConfig to return proper `UserDetails`

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d4c7b9c6c83208e429c4679c6fc7f