### PR TITLE
Add trophy description and retrieval without pagination

### DIFF
--- a/src/main/java/com/ubb/eventapp/controller/TrophyController.java
+++ b/src/main/java/com/ubb/eventapp/controller/TrophyController.java
@@ -1,0 +1,29 @@
+package com.ubb.eventapp.controller;
+
+import com.ubb.eventapp.model.Trophy;
+import com.ubb.eventapp.service.TrophyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/trophies")
+@RequiredArgsConstructor
+public class TrophyController {
+
+    private final TrophyService service;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Trophy> findById(@PathVariable Integer id) {
+        return service.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Trophy>> findByIds(@RequestParam("ids") List<Integer> ids) {
+        return ResponseEntity.ok(service.findByIds(ids));
+    }
+}

--- a/src/main/java/com/ubb/eventapp/model/Trophy.java
+++ b/src/main/java/com/ubb/eventapp/model/Trophy.java
@@ -18,4 +18,7 @@ public class Trophy {
 
     @Column(length = 80, unique = true)
     private String nombre;
+
+    @Column(columnDefinition = "TEXT")
+    private String descripcion;
 }

--- a/src/main/java/com/ubb/eventapp/repository/TrophyRepository.java
+++ b/src/main/java/com/ubb/eventapp/repository/TrophyRepository.java
@@ -3,5 +3,16 @@ package com.ubb.eventapp.repository;
 import com.ubb.eventapp.model.Trophy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface TrophyRepository extends JpaRepository<Trophy, Integer> {
+
+    /**
+     * Retrieves trophies with the specified identifiers.
+     *
+     * @param ids collection of trophy ids
+     * @return list of trophies matching the ids
+     */
+    List<Trophy> findByIdIn(Collection<Integer> ids);
 }

--- a/src/main/java/com/ubb/eventapp/service/TrophyService.java
+++ b/src/main/java/com/ubb/eventapp/service/TrophyService.java
@@ -1,0 +1,18 @@
+package com.ubb.eventapp.service;
+
+import com.ubb.eventapp.model.Trophy;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TrophyService {
+    Optional<Trophy> findById(Integer id);
+
+    /**
+     * Retrieves trophies matching the provided ids.
+     *
+     * @param ids list of trophy ids
+     * @return list of trophies
+     */
+    List<Trophy> findByIds(List<Integer> ids);
+}

--- a/src/main/java/com/ubb/eventapp/service/impl/TrophyServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/TrophyServiceImpl.java
@@ -1,0 +1,33 @@
+package com.ubb.eventapp.service.impl;
+
+import com.ubb.eventapp.model.Trophy;
+import com.ubb.eventapp.repository.TrophyRepository;
+import com.ubb.eventapp.service.TrophyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TrophyServiceImpl implements TrophyService {
+
+    private final TrophyRepository trophyRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Trophy> findById(Integer id) {
+        return trophyRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Trophy> findByIds(List<Integer> ids) {
+        return ids == null || ids.isEmpty()
+                ? List.of()
+                : trophyRepository.findByIdIn(ids);
+    }
+}

--- a/src/test/java/com/ubb/eventapp/service/impl/TrophyServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/TrophyServiceImplTest.java
@@ -1,0 +1,48 @@
+package com.ubb.eventapp.service.impl;
+
+import com.ubb.eventapp.model.Trophy;
+import com.ubb.eventapp.repository.TrophyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class TrophyServiceImplTest {
+
+    private TrophyRepository trophyRepository;
+    private TrophyServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        trophyRepository = mock(TrophyRepository.class);
+        service = new TrophyServiceImpl(trophyRepository);
+    }
+
+    @Test
+    void findById_delegatesToRepository() {
+        when(trophyRepository.findById(1)).thenReturn(Optional.of(new Trophy()));
+
+        Optional<Trophy> result = service.findById(1);
+
+        assertTrue(result.isPresent());
+        verify(trophyRepository).findById(1);
+    }
+
+    @Test
+    void findByIds_usesRepository() {
+        when(trophyRepository.findByIdIn(List.of(1, 2)))
+                .thenReturn(List.of(new Trophy(), new Trophy()));
+
+        List<Trophy> result = service.findByIds(List.of(1, 2));
+
+        assertEquals(2, result.size());
+        ArgumentCaptor<List<Integer>> captor = ArgumentCaptor.forClass(List.class);
+        verify(trophyRepository).findByIdIn(captor.capture());
+        assertEquals(List.of(1, 2), captor.getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- add `descripcion` field to `Trophy`
- query trophies by IDs without pagination
- expose non-paginated endpoints
- adjust repository, service, and tests

## Testing
- `mvn -B -V test` *(fails: could not resolve maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d587e704c832085c8194c28f62195