### PR TITLE
Add Postman collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ The application reads the MySQL connection details from environment variables. C
 - `DB_PASSWORD` – database password
 
 Defaults are provided for local development if the variables are not set.
+
+## API Testing with Postman
+A Postman collection with all endpoints is provided under the `postman` folder. Import `postman/EventApp.postman_collection.json` into Postman and set the `baseUrl` variable to match your running server (e.g. `http://localhost:8080`).
+

--- a/postman/EventApp.postman_collection.json
+++ b/postman/EventApp.postman_collection.json
@@ -1,0 +1,291 @@
+{
+  "info": {
+    "name": "EventApp API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Authentication",
+      "item": [
+        {
+          "name": "Register",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/auth/register"
+          }
+        },
+        {
+          "name": "Login",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/auth/login"
+          }
+        },
+        {
+          "name": "Refresh Token",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/auth/refresh"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Users",
+      "item": [
+        {
+          "name": "Update Profile",
+          "request": {
+            "method": "PUT",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/users"
+          }
+        },
+        {
+          "name": "Get User",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/users/:id"
+          }
+        },
+        {
+          "name": "Profile Summary",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/users/:id/summary"
+          }
+        },
+        {
+          "name": "Profile Events",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/users/:id/events"
+          }
+        },
+        {
+          "name": "Calendar",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/users/:id/calendar"
+          }
+        },
+        {
+          "name": "Events To Attend",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/users/:id/to-attend"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Events",
+      "item": [
+        {
+          "name": "Create Event",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/events"
+          }
+        },
+        {
+          "name": "Update Event",
+          "request": {
+            "method": "PUT",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/events"
+          }
+        },
+        {
+          "name": "Approve Event",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/events/:id/approve"
+          }
+        },
+        {
+          "name": "Find Event By Id",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/events/:id"
+          }
+        },
+        {
+          "name": "Events By Creator",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/events/creator/:userId"
+          }
+        },
+        {
+          "name": "Events By Group",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/events/group/:groupId"
+          }
+        },
+        {
+          "name": "Upcoming Events",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/events/upcoming"
+          }
+        },
+        {
+          "name": "Events By Ids",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/events"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Registrations",
+      "item": [
+        {
+          "name": "Register For Event",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/registrations"
+          }
+        },
+        {
+          "name": "Cancel Registration",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/registrations/cancel"
+          }
+        },
+        {
+          "name": "Get Registration",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/registrations/:eventId/:userId"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Friendships",
+      "item": [
+        {
+          "name": "Request Friendship",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/friendships"
+          }
+        },
+        {
+          "name": "Accept Friendship",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/friendships/accept"
+          }
+        },
+        {
+          "name": "Get Friendship",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/friendships/:user1/:user2"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Groups",
+      "item": [
+        {
+          "name": "Create Group",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/groups"
+          }
+        },
+        {
+          "name": "Update Group",
+          "request": {
+            "method": "PUT",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/groups"
+          }
+        },
+        {
+          "name": "Get Group By Id",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/groups/:id"
+          }
+        },
+        {
+          "name": "Groups By Representative",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/groups/representative/:userId"
+          }
+        },
+        {
+          "name": "Groups By Tags",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/groups/tags"
+          }
+        },
+        {
+          "name": "Search Groups",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/groups/search"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Support Tickets",
+      "item": [
+        {
+          "name": "Open Ticket",
+          "request": {
+            "method": "POST",
+            "header": [{"key": "Content-Type", "value": "application/json"}],
+            "body": {"mode": "raw", "raw": "{}"},
+            "url": "{{baseUrl}}/tickets"
+          }
+        },
+        {
+          "name": "Close Ticket",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/tickets/:id/close"
+          }
+        },
+        {
+          "name": "Get Ticket",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/tickets/:id"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Postman collection covering all API endpoints
- document Postman usage in README

## Testing
- `mvn -B -V clean verify` *(fails: could not download Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686d5a4134348320b3f048dc690d7343