### PR TITLE
Add userId claim to JWT tokens

### DIFF
--- a/src/main/java/com/ubb/eventapp/service/auth/AuthenticationServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/auth/AuthenticationServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -67,8 +68,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                 .build();
         User savedUser = userRepository.save(user);
         UserDetails userDetails = asUserDetails(savedUser);
-        String jwtToken = jwtService.generateToken(userDetails);
-        String refreshToken = jwtService.generateToken(userDetails);
+        String jwtToken = jwtService.generateToken(Map.of("userId", savedUser.getId()), userDetails);
+        String refreshToken = jwtService.generateToken(Map.of("userId", savedUser.getId()), userDetails);
         saveUserToken(savedUser, jwtToken);
         return AuthenticationResponse.builder()
                 .accessToken(jwtToken)
@@ -91,8 +92,8 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         User user = userRepository.findByCorreoUbb(request.getEmail())
                 .orElseThrow();
         UserDetails userDetails = asUserDetails(user);
-        String jwtToken = jwtService.generateToken(userDetails);
-        String refreshToken = jwtService.generateToken(userDetails);
+        String jwtToken = jwtService.generateToken(Map.of("userId", user.getId()), userDetails);
+        String refreshToken = jwtService.generateToken(Map.of("userId", user.getId()), userDetails);
         revokeAllUserTokens(user);
         saveUserToken(user, jwtToken);
         return AuthenticationResponse.builder()
@@ -115,7 +116,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             User user = userRepository.findByCorreoUbb(userEmail).orElseThrow();
             UserDetails userDetails = asUserDetails(user);
             if (jwtService.isTokenValid(refreshToken, userDetails)) {
-                String accessToken = jwtService.generateToken(userDetails);
+                String accessToken = jwtService.generateToken(Map.of("userId", user.getId()), userDetails);
                 revokeAllUserTokens(user);
                 saveUserToken(user, accessToken);
                 AuthenticationResponse authResponse = AuthenticationResponse.builder()

--- a/src/test/java/com/ubb/eventapp/security/services/JwtServiceTest.java
+++ b/src/test/java/com/ubb/eventapp/security/services/JwtServiceTest.java
@@ -25,9 +25,10 @@ public class JwtServiceTest {
     @Test
     void generateAndValidateToken() {
         UserDetails user = User.withUsername("user@test.com").password("pass").authorities("USER").build();
-        String token = service.generateToken(user);
+        String token = service.generateToken(java.util.Map.of("userId", 1L), user);
         assertNotNull(token);
         assertEquals("user@test.com", service.extractUsername(token));
+        assertEquals(1L, service.extractClaim(token, c -> c.get("userId", Long.class)));
         assertTrue(service.isTokenValid(token, user));
     }
 }


### PR DESCRIPTION
## Summary
- include a `userId` claim when generating JWT tokens
- verify claim extraction in `JwtServiceTest`

## Testing
- `mvn -B clean test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888fb202e608320ad2bd0d68d97dd48