### PR TITLE
Add public events endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -170,6 +170,9 @@ Lists events belonging to a group.
 ### `GET /events/upcoming?after={datetime}`
 Lists upcoming events after the given ISO date-time.
 
+### `GET /events/public`
+Lists all public events.
+
 ### `GET /events?ids=1&ids=2`
 Fetches multiple events by id.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -233,6 +233,20 @@ curl "http://localhost:8080/events/upcoming?after=2025-01-01T00:00:00"
 ]
 ```
 
+### Public Events
+- **GET** `/events/public`
+
+Example:
+```bash
+curl http://localhost:8080/events/public
+```
+- **Response**:
+```json
+[
+  {"id":1,"titulo":"Charla"}
+]
+```
+
 ### Events By Ids
 - **GET** `/events?ids=1,2,3`
 

--- a/src/main/java/com/ubb/eventapp/controller/EventController.java
+++ b/src/main/java/com/ubb/eventapp/controller/EventController.java
@@ -49,6 +49,11 @@ public class EventController {
         return ResponseEntity.ok(service.findByGroup(groupId));
     }
 
+    @GetMapping("/public")
+    public ResponseEntity<List<Event>> findPublic() {
+        return ResponseEntity.ok(service.findPublicEvents());
+    }
+
     @GetMapping("/upcoming")
     public ResponseEntity<List<Event>> findUpcoming(@RequestParam(required = false)
                                                     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/com/ubb/eventapp/service/EventService.java
+++ b/src/main/java/com/ubb/eventapp/service/EventService.java
@@ -15,6 +15,13 @@ public interface EventService {
     java.util.List<Event> findUpcomingEvents(java.time.LocalDateTime after);
 
     /**
+     * Retrieves all public events.
+     *
+     * @return list of events with PUBLICO visibility
+     */
+    java.util.List<Event> findPublicEvents();
+
+    /**
      * Retrieves the events with the provided identifiers.
      *
      * @param ids list of event ids

--- a/src/main/java/com/ubb/eventapp/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/EventServiceImpl.java
@@ -60,6 +60,12 @@ public class EventServiceImpl implements EventService {
 
     @Override
     @Transactional(readOnly = true)
+    public java.util.List<Event> findPublicEvents() {
+        return eventRepository.findByVisibilidad(com.ubb.eventapp.model.Visibility.PUBLICO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public java.util.List<Event> findByIds(java.util.List<Long> ids) {
         return ids == null || ids.isEmpty() ? java.util.Collections.emptyList() :
                 eventRepository.findAllById(ids);

--- a/src/test/java/com/ubb/eventapp/service/impl/EventServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/EventServiceImplTest.java
@@ -2,6 +2,7 @@ package com.ubb.eventapp.service.impl;
 
 import com.ubb.eventapp.model.Event;
 import com.ubb.eventapp.model.ValidationState;
+import com.ubb.eventapp.model.Visibility;
 import com.ubb.eventapp.repository.EventRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,5 +46,12 @@ public class EventServiceImplTest {
         service.findByIds(List.of(1L, 2L));
 
         verify(eventRepository).findAllById(List.of(1L, 2L));
+    }
+
+    @Test
+    void findPublicEvents_delegatesToRepository() {
+        service.findPublicEvents();
+
+        verify(eventRepository).findByVisibilidad(Visibility.PUBLICO);
     }
 }


### PR DESCRIPTION
## Summary
- expose `findPublicEvents` in `EventService` and implementation
- add `/events/public` route in `EventController`
- document the new endpoint in API docs
- unit-test service method

## Testing
- `mvn -B clean verify` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68891ede2eb48320bcbdc376d6fa342c