### PR TITLE
Fix unit tests IDs & jwt key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Defaults are provided for local development if not set.
 Run the Maven build and tests using:
 
 ```bash
-mvn -B clean verify
+./build.sh
 ```
 
-A standard Java 17 JDK and Maven 3.8+ are required. See `agent.md` for a full build recipe.
+A standard Java 17 JDK and Maven 3.8+ are required. See `build.sh` for a full build recipe derived from `agent.md`.
 
 ## Documentation
 Detailed table definitions can be found in [docs/DATABASE.md](docs/DATABASE.md).

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mvn -B clean verify

--- a/src/test/java/com/ubb/eventapp/security/services/JwtServiceTest.java
+++ b/src/test/java/com/ubb/eventapp/security/services/JwtServiceTest.java
@@ -17,7 +17,8 @@ public class JwtServiceTest {
     @BeforeEach
     void setup() {
         service = new JwtService();
-        String key = Base64.getEncoder().encodeToString("test-key".getBytes());
+        String keyMaterial = "0123456789abcdef0123456789abcdef"; // 32 bytes
+        String key = Base64.getEncoder().encodeToString(keyMaterial.getBytes());
         ReflectionTestUtils.setField(service, "secretKey", key);
         ReflectionTestUtils.setField(service, "jwtExpiration", 3600000L);
     }

--- a/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
@@ -26,7 +26,7 @@ public class FriendshipServiceImplTest {
 
     @Test
     void acceptFriendship_setsStateToAcceptedAndSaves() {
-        FriendshipId id = new FriendshipId(1l, 2l);
+        FriendshipId id = new FriendshipId(1L, 2L);
         Friendship friendship = Friendship.builder().id(id).estado(FriendshipState.PENDIENTE).build();
         when(friendshipRepository.findById(id)).thenReturn(Optional.of(friendship));
         when(friendshipRepository.save(any(Friendship.class))).thenAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/ubb/eventapp/service/impl/RegistrationServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/RegistrationServiceImplTest.java
@@ -26,7 +26,7 @@ public class RegistrationServiceImplTest {
 
     @Test
     void cancelRegistration_setsStateToCanceledAndSaves() {
-        RegistrationId id = new RegistrationId(1l, 2l);
+        RegistrationId id = new RegistrationId(1L, 2L);
         Registration reg = Registration.builder().id(id).estado(RegistrationState.INSCRITO).build();
         when(registrationRepository.findById(id)).thenReturn(Optional.of(reg));
         when(registrationRepository.save(any(Registration.class))).thenAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/ubb/eventapp/service/impl/SupportTicketServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/SupportTicketServiceImplTest.java
@@ -25,11 +25,11 @@ public class SupportTicketServiceImplTest {
 
     @Test
     void closeTicket_setsStateToClosedAndSaves() {
-        SupportTicket ticket = SupportTicket.builder().id(1l).estado(TicketState.ABIERTO).build();
-        when(supportTicketRepository.findById(1l)).thenReturn(Optional.of(ticket));
+        SupportTicket ticket = SupportTicket.builder().id(1L).estado(TicketState.ABIERTO).build();
+        when(supportTicketRepository.findById(1L)).thenReturn(Optional.of(ticket));
         when(supportTicketRepository.save(any(SupportTicket.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        SupportTicket result = service.closeTicket(1l);
+        SupportTicket result = service.closeTicket(1L);
 
         assertEquals(TicketState.CERRADO, result.getEstado());
         ArgumentCaptor<SupportTicket> captor = ArgumentCaptor.forClass(SupportTicket.class);

--- a/src/test/java/com/ubb/eventapp/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/UserServiceImplTest.java
@@ -81,6 +81,8 @@ public class UserServiceImplTest {
                 .build();
         when(registrationRepository.findByUser_IdAndEstado(1L, RegistrationState.INSCRITO))
                 .thenReturn(List.of(toAttend));
+        when(eventRepository.findAllById(List.of(3L)))
+                .thenReturn(List.of(toAttend.getEvent()));
 
         ProfileEvents result = service.getProfileEvents(1L);
 


### PR DESCRIPTION
## Summary
- fix ID types in unit tests
- add build script and doc reference
- use secure key in JwtServiceTest
- stub `findAllById` for calendar test

## Testing
- `mvn -B clean verify` *(fails: could not resolve plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68891d70a77c832081d2741d728e3f38