### PR TITLE
Fix event deletion with dependencies

### DIFF
--- a/src/main/java/com/ubb/eventapp/repository/RegistrationRepository.java
+++ b/src/main/java/com/ubb/eventapp/repository/RegistrationRepository.java
@@ -17,4 +17,11 @@ public interface RegistrationRepository extends JpaRepository<Registration, Regi
      * @return list of registrations that match
      */
     List<Registration> findByUser_IdAndEstado(Long userId, RegistrationState estado);
+
+    /**
+     * Deletes all registrations associated with the provided event.
+     *
+     * @param eventId identifier of the event
+     */
+    void deleteByEvent_Id(Long eventId);
 }

--- a/src/main/java/com/ubb/eventapp/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/EventServiceImpl.java
@@ -3,6 +3,8 @@ package com.ubb.eventapp.service.impl;
 import com.ubb.eventapp.model.Event;
 import com.ubb.eventapp.model.ValidationState;
 import com.ubb.eventapp.repository.EventRepository;
+import com.ubb.eventapp.repository.EventReviewRepository;
+import com.ubb.eventapp.repository.RegistrationRepository;
 import com.ubb.eventapp.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,8 @@ import java.util.Optional;
 public class EventServiceImpl implements EventService {
 
     private final EventRepository eventRepository;
+    private final EventReviewRepository eventReviewRepository;
+    private final RegistrationRepository registrationRepository;
 
     @Override
     public Event createEvent(Event event) {
@@ -37,6 +41,9 @@ public class EventServiceImpl implements EventService {
     @Override
     public void deleteEvent(Long eventId) {
         eventRepository.findById(eventId).orElseThrow();
+        // Remove dependent records first to satisfy foreign key constraints
+        registrationRepository.deleteByEvent_Id(eventId);
+        eventReviewRepository.deleteById(eventId);
         eventRepository.deleteById(eventId);
     }
 


### PR DESCRIPTION
## Summary
- ensure event deletions also remove related registrations and event revisions
- extend `RegistrationRepository` with `deleteByEvent_Id`

## Testing
- `./build.sh` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688938211b108320917bd89514b868bd