### PR TITLE
Add friend listing and deletion endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -268,6 +268,12 @@ Lists pending friendship requests for a user.
 ### `GET /friendships/{user1}/{user2}`
 Gets friendship info.
 
+### `GET /friendships/friends/{userId}`
+Lists accepted friends of a user.
+
+### `DELETE /friendships/{user1}/{user2}`
+Deletes a friendship.
+
 ## Groups
 
 ### `POST /groups`

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -410,6 +410,22 @@ curl http://localhost:8080/friendships/1/2
 }
 ```
 
+### List Friends
+- **GET** `/friendships/friends/{userId}`
+- **Curl**:
+```bash
+curl http://localhost:8080/friendships/friends/1
+```
+- **Response**: list of `User`.
+
+### Delete Friendship
+- **DELETE** `/friendships/{user1}/{user2}`
+- **Curl**:
+```bash
+curl -X DELETE http://localhost:8080/friendships/1/2
+```
+- **Response**: `200 OK` with empty body.
+
 ## Groups
 
 ### Create Group

--- a/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
+++ b/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
@@ -34,11 +34,23 @@ public class FriendshipController {
         return ResponseEntity.ok(service.findPendingFriendships(userId));
     }
 
+    @GetMapping("/friends/{userId}")
+    public ResponseEntity<java.util.List<com.ubb.eventapp.model.User>> friends(@PathVariable Long userId) {
+        return ResponseEntity.ok(service.findFriends(userId));
+    }
+
     @GetMapping("/{user1}/{user2}")
     public ResponseEntity<Friendship> findById(@PathVariable Long user1, @PathVariable Long user2) {
         FriendshipId id = new FriendshipId(user1, user2);
         return service.findById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{user1}/{user2}")
+    public ResponseEntity<Void> delete(@PathVariable Long user1, @PathVariable Long user2) {
+        FriendshipId id = new FriendshipId(user1, user2);
+        service.deleteFriendship(id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ubb/eventapp/service/FriendshipService.java
+++ b/src/main/java/com/ubb/eventapp/service/FriendshipService.java
@@ -5,6 +5,7 @@ import com.ubb.eventapp.model.FriendshipId;
 import java.util.List;
 
 import java.util.Optional;
+import com.ubb.eventapp.model.User;
 
 public interface FriendshipService {
     Friendship requestFriendship(Friendship friendship);
@@ -12,4 +13,6 @@ public interface FriendshipService {
     Friendship rejectFriendship(FriendshipId id);
     List<Friendship> findPendingFriendships(Long userId);
     Optional<Friendship> findById(FriendshipId id);
+    List<User> findFriends(Long userId);
+    void deleteFriendship(FriendshipId id);
 }

--- a/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
@@ -5,6 +5,7 @@ import com.ubb.eventapp.model.FriendshipId;
 import com.ubb.eventapp.model.FriendshipState;
 import com.ubb.eventapp.repository.FriendshipRepository;
 import com.ubb.eventapp.service.FriendshipService;
+import com.ubb.eventapp.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,5 +48,20 @@ public class FriendshipServiceImpl implements FriendshipService {
     @Transactional(readOnly = true)
     public Optional<Friendship> findById(FriendshipId id) {
         return friendshipRepository.findById(id);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public java.util.List<User> findFriends(Long userId) {
+        return friendshipRepository
+                .findByUserIdAndEstado(userId, FriendshipState.ACEPTADA)
+                .stream()
+                .map(f -> f.getUser1().getId().equals(userId) ? f.getUser2() : f.getUser1())
+                .toList();
+    }
+
+    @Override
+    public void deleteFriendship(FriendshipId id) {
+        friendshipRepository.deleteById(id);
     }
 }

--- a/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
@@ -4,6 +4,7 @@ import com.ubb.eventapp.model.Friendship;
 import com.ubb.eventapp.model.FriendshipId;
 import com.ubb.eventapp.model.FriendshipState;
 import com.ubb.eventapp.repository.FriendshipRepository;
+import com.ubb.eventapp.model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -52,5 +53,35 @@ public class FriendshipServiceImplTest {
         ArgumentCaptor<Friendship> captor = ArgumentCaptor.forClass(Friendship.class);
         verify(friendshipRepository).save(captor.capture());
         assertEquals(FriendshipState.BLOQUEADA, captor.getValue().getEstado());
+    }
+
+    @Test
+    void findFriends_returnsOtherUsersInAcceptedFriendships() {
+        Long userId = 1L;
+        Friendship f1 = Friendship.builder()
+                .user1(User.builder().id(userId).build())
+                .user2(User.builder().id(2L).build())
+                .estado(FriendshipState.ACEPTADA)
+                .build();
+        Friendship f2 = Friendship.builder()
+                .user1(User.builder().id(3L).build())
+                .user2(User.builder().id(userId).build())
+                .estado(FriendshipState.ACEPTADA)
+                .build();
+        when(friendshipRepository.findByUserIdAndEstado(userId, FriendshipState.ACEPTADA))
+                .thenReturn(java.util.List.of(f1, f2));
+
+        java.util.List<User> result = service.findFriends(userId);
+
+        assertEquals(java.util.List.of(f1.getUser2(), f2.getUser1()), result);
+    }
+
+    @Test
+    void deleteFriendship_delegatesToRepository() {
+        FriendshipId id = new FriendshipId(1L, 2L);
+
+        service.deleteFriendship(id);
+
+        verify(friendshipRepository).deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- add endpoints to list friends and delete friendships
- implement service logic and tests for listing/deleting friends
- document new API endpoints

## Testing
- `mvn -B clean verify` *(fails: could not resolve maven-clean-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68894830a8108320b860b125e0a90810