### PR TITLE
Add endpoint for path-based friendship creation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -244,6 +244,15 @@ Response example:
 {"id":{"user1Id":1,"user2Id":2},"estado":"PENDIENTE"}
 ```
 
+You can also send the user ids as path parameters:
+
+### `POST /friendships/{user1Id}/{user2Id}`
+
+```bash
+curl -X POST "$BASE_URL/friendships/1/2"
+```
+Response example is identical to the body-based variant.
+
 ### `POST /friendships/accept`
 Accepts a friendship.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -360,6 +360,14 @@ curl -X POST http://localhost:8080/friendships \
 ```
 - **Response**: `Friendship`.
 
+You can also pass the ids in the path:
+
+- **POST** `/friendships/{user1Id}/{user2Id}`
+```bash
+curl -X POST http://localhost:8080/friendships/1/2
+```
+Response body is the same as above.
+
 ### Accept Friendship
 - **POST** `/friendships/accept`
 - **Request body**:

--- a/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
+++ b/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
@@ -19,6 +19,15 @@ public class FriendshipController {
         return ResponseEntity.ok(service.requestFriendship(friendship));
     }
 
+    @PostMapping("/{user1Id}/{user2Id}")
+    public ResponseEntity<Friendship> requestByIds(@PathVariable Long user1Id,
+                                                   @PathVariable Long user2Id) {
+        Friendship friendship = Friendship.builder()
+                .id(new FriendshipId(user1Id, user2Id))
+                .build();
+        return ResponseEntity.ok(service.requestFriendship(friendship));
+    }
+
     @PostMapping("/accept")
     public ResponseEntity<Friendship> accept(@RequestBody FriendshipId id) {
         return ResponseEntity.ok(service.acceptFriendship(id));


### PR DESCRIPTION
## Summary
- allow friendship request with `/friendships/{user1Id}/{user2Id}`
- document the new endpoint in API docs

## Testing
- `./build.sh` *(fails: Could not resolve maven-clean-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688983a4474c8320b2fe9939c363bd35