### PR TITLE
Fix builder defaults for entity enums

### DIFF
--- a/src/main/java/com/ubb/eventapp/model/Event.java
+++ b/src/main/java/com/ubb/eventapp/model/Event.java
@@ -18,6 +18,7 @@ public class Event {
     @Column(name = "id_evento")
     private Long id;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "origen_tipo")
     private EventSourceType origenTipo = EventSourceType.USUARIO;
@@ -48,9 +49,11 @@ public class Event {
     @Column(name = "aforo_max")
     private Integer aforoMax;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     private Visibility visibilidad = Visibility.PUBLICO;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "estado_validacion")
     private ValidationState estadoValidacion = ValidationState.PENDIENTE;

--- a/src/main/java/com/ubb/eventapp/model/Friendship.java
+++ b/src/main/java/com/ubb/eventapp/model/Friendship.java
@@ -14,6 +14,7 @@ public class Friendship {
     @EmbeddedId
     private FriendshipId id;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private FriendshipState estado = FriendshipState.PENDIENTE;

--- a/src/main/java/com/ubb/eventapp/model/GroupMember.java
+++ b/src/main/java/com/ubb/eventapp/model/GroupMember.java
@@ -24,6 +24,7 @@ public class GroupMember {
     @JoinColumn(name = "id_usuario")
     private User user;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "rol_grupo", nullable = false)
     private GroupRole rolGrupo = GroupRole.USUARIO;

--- a/src/main/java/com/ubb/eventapp/model/Registration.java
+++ b/src/main/java/com/ubb/eventapp/model/Registration.java
@@ -24,6 +24,7 @@ public class Registration {
     @JoinColumn(name = "id_usuario")
     private User user;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private RegistrationState estado = RegistrationState.INSCRITO;

--- a/src/main/java/com/ubb/eventapp/model/SupportTicket.java
+++ b/src/main/java/com/ubb/eventapp/model/SupportTicket.java
@@ -23,6 +23,7 @@ public class SupportTicket {
     @Column(columnDefinition = "TEXT")
     private String descripcion;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private TicketState estado = TicketState.ABIERTO;

--- a/src/main/java/com/ubb/eventapp/model/Token.java
+++ b/src/main/java/com/ubb/eventapp/model/Token.java
@@ -17,6 +17,7 @@ public class Token {
     @Column(unique = true, name = "access_token")
     private String accessToken;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     private TokenType tokenType = TokenType.BEARER;
 

--- a/src/main/java/com/ubb/eventapp/model/User.java
+++ b/src/main/java/com/ubb/eventapp/model/User.java
@@ -40,6 +40,7 @@ public class User {
     @Column(length = 255)
     private String password;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserState estado = UserState.ACTIVO;

--- a/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
@@ -104,6 +104,7 @@ public class FriendshipServiceImplTest {
 
         assertSame(u1, result.getUser1());
         assertSame(u2, result.getUser2());
+        assertEquals(FriendshipState.PENDIENTE, result.getEstado());
         verify(friendshipRepository).save(friendship);
     }
 }


### PR DESCRIPTION
## Summary
- ensure Lombok builders set default enum states on models
- verify friendship requests store `PENDIENTE` state

## Testing
- `./build.sh` *(fails: maven plugins could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_6889876fc0b48320aba2cfd9c3b94c88