### PR TITLE
Return users for pending friendships

### DIFF
--- a/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
+++ b/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
@@ -39,7 +39,7 @@ public class FriendshipController {
     }
 
     @GetMapping("/pending/{userId}")
-    public ResponseEntity<java.util.List<Friendship>> pending(@PathVariable Long userId) {
+    public ResponseEntity<java.util.List<com.ubb.eventapp.model.User>> pending(@PathVariable Long userId) {
         return ResponseEntity.ok(service.findPendingFriendships(userId));
     }
 

--- a/src/main/java/com/ubb/eventapp/service/FriendshipService.java
+++ b/src/main/java/com/ubb/eventapp/service/FriendshipService.java
@@ -11,7 +11,14 @@ public interface FriendshipService {
     Friendship requestFriendship(Friendship friendship);
     Friendship acceptFriendship(FriendshipId id);
     Friendship rejectFriendship(FriendshipId id);
-    List<Friendship> findPendingFriendships(Long userId);
+    /**
+     * Lists the users that have a pending friendship relation with the given
+     * user.
+     *
+     * @param userId identifier of the user
+     * @return users awaiting this user's response
+     */
+    java.util.List<User> findPendingFriendships(Long userId);
     Optional<Friendship> findById(FriendshipId id);
     List<User> findFriends(Long userId);
     void deleteFriendship(FriendshipId id);

--- a/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
@@ -54,8 +54,12 @@ public class FriendshipServiceImpl implements FriendshipService {
 
     @Override
     @Transactional(readOnly = true)
-    public java.util.List<Friendship> findPendingFriendships(Long userId) {
-        return friendshipRepository.findByUserIdAndEstado(userId, FriendshipState.PENDIENTE);
+    public java.util.List<User> findPendingFriendships(Long userId) {
+        return friendshipRepository
+                .findByUserIdAndEstado(userId, FriendshipState.PENDIENTE)
+                .stream()
+                .map(f -> f.getUser1().getId().equals(userId) ? f.getUser2() : f.getUser1())
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return pending friend requests as users instead of friendship records

## Testing
- `bash build.sh` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68898e337f908320ab6d6bc63553e92b