### PR TITLE
Update friend request accept/reject endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -253,22 +253,18 @@ curl -X POST "$BASE_URL/friendships/1/2"
 ```
 Response example is identical to the body-based variant.
 
-### `POST /friendships/accept`
+### `POST /friendships/{user1Id}/{user2Id}/accept`
 Accepts a friendship.
 
 ```bash
-curl -X POST "$BASE_URL/friendships/accept" \
-  -H "Content-Type: application/json" \
-  -d '{"user1Id":1,"user2Id":2}'
+curl -X POST "$BASE_URL/friendships/1/2/accept"
 ```
 
-### `POST /friendships/reject`
+### `POST /friendships/{user1Id}/{user2Id}/reject`
 Rejects a friendship request.
 
 ```bash
-curl -X POST "$BASE_URL/friendships/reject" \
-  -H "Content-Type: application/json" \
-  -d '{"user1Id":1,"user2Id":2}'
+curl -X POST "$BASE_URL/friendships/1/2/reject"
 ```
 
 ### `GET /friendships/pending/{userId}`

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -369,32 +369,18 @@ curl -X POST http://localhost:8080/friendships/1/2
 Response body is the same as above.
 
 ### Accept Friendship
-- **POST** `/friendships/accept`
-- **Request body**:
-```json
-{"user1Id": 1, "user2Id": 2}
-```
-- **Curl**:
+- **POST** `/friendships/{user1Id}/{user2Id}/accept`
 ```bash
-curl -X POST http://localhost:8080/friendships/accept \
-  -H 'Content-Type: application/json' \
-  -d '{"user1Id":1,"user2Id":2}'
+curl -X POST http://localhost:8080/friendships/1/2/accept
 ```
 - **Response**: updated `Friendship`.
 
 ### Reject Friendship
-- **POST** `/friendships/reject`
-- **Request body**:
-```json
-{"user1Id": 1, "user2Id": 2}
-```
-- **Curl**:
+- **POST** `/friendships/{user1Id}/{user2Id}/reject`
 ```bash
-curl -X POST http://localhost:8080/friendships/reject \
-  -H 'Content-Type: application/json' \
-  -d '{"user1Id":1,"user2Id":2}'
+curl -X POST http://localhost:8080/friendships/1/2/reject
 ```
-- **Response**: updated `Friendship`.
+- **Response**: `200 OK` with empty body.
 
 ### Pending Friendships
 - **GET** `/friendships/pending/{userId}`

--- a/postman/EventApp.postman_collection.json
+++ b/postman/EventApp.postman_collection.json
@@ -258,17 +258,14 @@
           "name": "Accept Friendship",
           "request": {
             "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\"user1Id\": \"user1\", \"user2Id\": \"user2\"}"
-            },
-            "url": "{{baseUrl}}/friendships/accept"
+            "url": "{{baseUrl}}/friendships/:user1/:user2/accept"
+          }
+        },
+        {
+          "name": "Reject Friendship",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/friendships/:user1/:user2/reject"
           }
         },
         {

--- a/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
+++ b/src/main/java/com/ubb/eventapp/controller/FriendshipController.java
@@ -28,14 +28,19 @@ public class FriendshipController {
         return ResponseEntity.ok(service.requestFriendship(friendship));
     }
 
-    @PostMapping("/accept")
-    public ResponseEntity<Friendship> accept(@RequestBody FriendshipId id) {
+    @PostMapping("/{user1Id}/{user2Id}/accept")
+    public ResponseEntity<Friendship> accept(@PathVariable Long user1Id,
+                                             @PathVariable Long user2Id) {
+        FriendshipId id = new FriendshipId(user1Id, user2Id);
         return ResponseEntity.ok(service.acceptFriendship(id));
     }
 
-    @PostMapping("/reject")
-    public ResponseEntity<Friendship> reject(@RequestBody FriendshipId id) {
-        return ResponseEntity.ok(service.rejectFriendship(id));
+    @PostMapping("/{user1Id}/{user2Id}/reject")
+    public ResponseEntity<Void> reject(@PathVariable Long user1Id,
+                                       @PathVariable Long user2Id) {
+        FriendshipId id = new FriendshipId(user1Id, user2Id);
+        service.rejectFriendship(id);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/pending/{userId}")

--- a/src/main/java/com/ubb/eventapp/service/FriendshipService.java
+++ b/src/main/java/com/ubb/eventapp/service/FriendshipService.java
@@ -10,7 +10,12 @@ import com.ubb.eventapp.model.User;
 public interface FriendshipService {
     Friendship requestFriendship(Friendship friendship);
     Friendship acceptFriendship(FriendshipId id);
-    Friendship rejectFriendship(FriendshipId id);
+    /**
+     * Removes a pending friendship request.
+     *
+     * @param id identifier of the friendship
+     */
+    void rejectFriendship(FriendshipId id);
     /**
      * Lists the users that have a pending friendship relation with the given
      * user.

--- a/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
@@ -46,10 +46,8 @@ public class FriendshipServiceImpl implements FriendshipService {
     }
 
     @Override
-    public Friendship rejectFriendship(FriendshipId id) {
-        Friendship friendship = friendshipRepository.findById(id).orElseThrow();
-        friendship.setEstado(FriendshipState.BLOQUEADA);
-        return friendshipRepository.save(friendship);
+    public void rejectFriendship(FriendshipId id) {
+        friendshipRepository.deleteById(id);
     }
 
     @Override

--- a/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
@@ -44,18 +44,12 @@ public class FriendshipServiceImplTest {
     }
 
     @Test
-    void rejectFriendship_setsStateToBlockedAndSaves() {
+    void rejectFriendship_deletesRequest() {
         FriendshipId id = new FriendshipId(1L, 2L);
-        Friendship friendship = Friendship.builder().id(id).estado(FriendshipState.PENDIENTE).build();
-        when(friendshipRepository.findById(id)).thenReturn(Optional.of(friendship));
-        when(friendshipRepository.save(any(Friendship.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        Friendship result = service.rejectFriendship(id);
+        service.rejectFriendship(id);
 
-        assertEquals(FriendshipState.BLOQUEADA, result.getEstado());
-        ArgumentCaptor<Friendship> captor = ArgumentCaptor.forClass(Friendship.class);
-        verify(friendshipRepository).save(captor.capture());
-        assertEquals(FriendshipState.BLOQUEADA, captor.getValue().getEstado());
+        verify(friendshipRepository).deleteById(id);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- modify friendship accept/reject API paths
- remove body payload from accept/reject calls in docs and Postman
- rejectFriendship now deletes request instead of blocking
- adjust tests for new behaviour

## Testing
- `./build.sh` *(fails: Could not resolve maven-clean-plugin from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68899070e3488320837f4b4ef5c36d64