### PR TITLE
Fix friendship acceptance when id order reversed

### DIFF
--- a/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
+++ b/src/main/java/com/ubb/eventapp/service/impl/FriendshipServiceImpl.java
@@ -40,7 +40,12 @@ public class FriendshipServiceImpl implements FriendshipService {
 
     @Override
     public Friendship acceptFriendship(FriendshipId id) {
-        Friendship friendship = friendshipRepository.findById(id).orElseThrow();
+        Optional<Friendship> friendshipOpt = friendshipRepository.findById(id);
+        if (friendshipOpt.isEmpty()) {
+            FriendshipId reversed = new FriendshipId(id.getUser2Id(), id.getUser1Id());
+            friendshipOpt = friendshipRepository.findById(reversed);
+        }
+        Friendship friendship = friendshipOpt.orElseThrow();
         friendship.setEstado(FriendshipState.ACEPTADA);
         return friendshipRepository.save(friendship);
     }

--- a/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
+++ b/src/test/java/com/ubb/eventapp/service/impl/FriendshipServiceImplTest.java
@@ -44,6 +44,23 @@ public class FriendshipServiceImplTest {
     }
 
     @Test
+    void acceptFriendship_looksForReverseIdIfNotFound() {
+        FriendshipId id = new FriendshipId(1L, 2L);
+        FriendshipId reversed = new FriendshipId(2L, 1L);
+        Friendship friendship = Friendship.builder().id(reversed).estado(FriendshipState.PENDIENTE).build();
+        when(friendshipRepository.findById(id)).thenReturn(Optional.empty());
+        when(friendshipRepository.findById(reversed)).thenReturn(Optional.of(friendship));
+        when(friendshipRepository.save(any(Friendship.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Friendship result = service.acceptFriendship(id);
+
+        assertEquals(FriendshipState.ACEPTADA, result.getEstado());
+        verify(friendshipRepository).findById(id);
+        verify(friendshipRepository).findById(reversed);
+        verify(friendshipRepository).save(friendship);
+    }
+
+    @Test
     void rejectFriendship_deletesRequest() {
         FriendshipId id = new FriendshipId(1L, 2L);
 


### PR DESCRIPTION
## Summary
- handle reversed IDs in `acceptFriendship`
- test reversed friendship ID behavior

## Testing
- `./build.sh` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889939e58888320818dcc9dac2afaff